### PR TITLE
bib file for all papers

### DIFF
--- a/working_notes/clef19_checkthat.bib
+++ b/working_notes/clef19_checkthat.bib
@@ -1,0 +1,143 @@
+@InProceedings{clef-checkthat:2019,
+ author = "Elsayed, Tamer and
+    Nakov, Preslav and
+    Barr\'{o}n-Cede{\~n}o, Alberto and
+    Hasanain, Maram and
+    Suwaileh, Reem and
+    {Da San Martino}, Giovanni and 
+    Atanasova, Pepa",
+ title  = "Overview of the CLEF-2019 CheckThat!: Automatic Identification and Verification of Claims",
+ booktitle = "Experimental IR Meets Multilinguality, Multimodality, and Interaction",
+ series    = "LNCS",
+ pubblisher = "Springer",
+ address   = "Lugano, Switzerland",
+ month     = "September",
+ year      = 2019
+}
+
+@InProceedings{clef-checkthat-T1:2019,
+    editor = "",
+    title  = "Overview of the CLEF-2019 CheckThat! Lab on Automatic Identification and Verification of Political Claims. Task 1: Check-Worthiness",
+    crossref = "clef-ceur:19"
+}
+
+@InProceedings{clef-checkthat-T2:2019,
+    editor = "",
+    title  = "Overview of the CLEF-2019 CheckThat! Lab on Automatic Identification and Verification of Political Claims. Task 2: Evidence and Factuality",
+    crossref = "clef-ceur:19"
+} 
+
+@proceedings{ClefCeur:2019,
+    editor = "",
+    title = "Working Notes of {CLEF} 2019 -- Conference and Labs of the Evaluation Forum",
+    series    = "{CEUR} Workshop Proceedings",
+    publisher = "CEUR-WS.org",
+    address   = "Lugano, Switzerland",
+    NOmonth   = "September",
+    year      = "2019"
+} 
+
+@InProceedings{T1-Altun:2019,
+    author    = "Altun, Bahadir and
+                Kutlu, Mucahid",
+    title     = "TOBB-ETU at CLEF 2019: Prioritizing Claims Based on Check-Worthiness",
+    crossref = "ClefCeur:2019"
+}
+
+@InProceedings{T1-Coca:2019,
+    author   = "Coca, {Lucia Georgiana} and
+            Cusmuliuc, Ciprian-Gabriel and
+            Iftene, Adrian",
+    title    = "CheckThat! 2019 UAICS",
+    crossref = "ClefCeur:2019"
+}
+
+@InProceedings{T1-Dhar:2019,
+    author    = "Dhar, Rudra and
+                Dutta, Subhabrata and
+                Das, Dipankar",
+    title     = "A Hybrid Model to Rank Sentences for Check-worthiness",
+    crossref = "ClefCeur:2019"
+}
+
+@InProceedings{T1-T2-Favano:2019,
+    author    = "Favano, Luca and
+                Carman, {Mark J.} and
+                Lanzi, {Pier Luca}",
+    title     = "TheEarthIsFlat’s Submission to CLEF’19CheckThat! Challenge",
+    crossref = "ClefCeur:2019"
+}
+
+
+@InProceedings{T1-Gasior:2019,
+    author    = "Gasior, Jakub and
+                Przyby{\l}a, Piotr ",
+    title     = "The IPIPAN Team Participation in the Check-Worthiness Task of the CLEF2019 CheckThat! Lab",
+    crossref = "ClefCeur:2019"
+}
+
+@InProceedings{T1-Hansen:2019,
+    author    = "Hansen, Casper and
+            Hansen, Christian and
+            Simonsen, {Jakob Grue} and
+            Lioma, Christina",
+    title     = "{Neural Weakly Supervised Fact Check-Worthiness Detection with Contrastive Sampling-Based Ranking Loss}",
+    crossref = "ClefCeur:2019"
+}
+
+@InProceedings{T1-Mohtaj:2019,
+    author    = "Mohtaj, Salar and
+                Himmelsbach, Tilo and
+                Woloszyn, Vinicius and
+                Möller, Sebastian",
+    title     = "The TU-Berlin Team Participation in the Check-Worthiness Task of the CLEF-2019 CheckThat! Lab",
+    crossref = "ClefCeur:2019"
+}
+
+@InProceedings{T1-Su:2019,
+    author    = "Su, Ting and
+                Macdonald, Craig and
+                Ounis, Iadh",
+    title     = "Entity Detection for Check-worthiness Prediction: Glasgow Terrier at CLEF CheckThat! 2019",
+    crossref = "ClefCeur:2019"
+}
+
+@InProceedings{T2-Ghanem:2019,
+    author    = "Ghanem, Bilal and
+                Glavaš, Goran and
+                Giachanou, Anastasia and
+                Ponzetto, {Simone Paolo} and
+                Rosso, Paolo and
+                Rangel, Francisco",
+    title     = "UPV-UMA at CheckThat! Lab: Verifying Arabic Claims using Cross Lingual Approach",
+    crossref = "ClefCeur:2019"
+}
+
+@InProceedings{T2Haouari:2019,
+    author    = "Haouari, Fatima and
+                Ali, {Zien Sheikh} and
+                Elsayed, Tamer",
+    title     = "bigIR at CLEF 2019: Automatic Verification of Arabic Claims over the Web",
+    crossref = "ClefCeur:2019"
+}
+
+@InProceedings{T2-Touahri:2019,
+    author    = "Touahri, Ibtissam and
+                Mazroui, Azzeddine ",
+    title     = "Automatic Identification and Verification of Political Claims",
+    crossref = "ClefCeur:2019"
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
A bibtext with all the papers from the 2019 edition. I used the same formatting conventions as in 2018.

The authors of the single-task overview papers remain pending. 